### PR TITLE
Add openSUSE support in contrib repo and fix xen-runtime/xorg-x11-utils packages

### DIFF
--- a/repos/Makefile
+++ b/repos/Makefile
@@ -30,6 +30,10 @@ install-vm-centos: install-centos
 	install -d $(DESTDIR)/etc/yum.repos.d
 	install -m 0644 qubes-contrib-vm-r4.1.repo-centos $(DESTDIR)/etc/yum.repos.d/qubes-contrib-vm-r4.1.repo
 
+install-vm-opensuse: install-opensuse
+	install -d $(DESTDIR)/etc/yum.repos.d
+	install -m 0644 qubes-contrib-vm-r4.1.repo-opensuse $(DESTDIR)/etc/yum.repos.d/qubes-contrib-vm-r4.1.repo
+
 install-fedora:
 	install -d $(DESTDIR)/etc/pki/rpm-gpg/
 	install -m 0644 qubesos-contrib-release-4-fedora.asc \
@@ -42,3 +46,9 @@ install-centos:
 		$(DESTDIR)/etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-centos
 	ln -s RPM-GPG-KEY-qubes-4-contrib-centos \
 		$(DESTDIR)/etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4.1-contrib-centos
+install-opensuse:
+	install -d $(DESTDIR)/etc/pki/rpm-gpg/
+	# Empty for now
+	touch $(DESTDIR)/etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-opensuse
+	ln -s RPM-GPG-KEY-qubes-4-contrib-centos \
+		$(DESTDIR)/etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4.1-contrib-opensuse

--- a/repos/qubes-contrib-vm-r4.1.repo-opensuse
+++ b/repos/qubes-contrib-vm-r4.1.repo-opensuse
@@ -1,0 +1,15 @@
+[qubes-contrib-vm-r4.1-current]
+name = Qubes OS Contrib Repository for VM (updates)
+baseurl = https://contrib.qubes-os.org/yum/r4.1/current/vm/opensuse/leap/$releasever
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-centos
+skip_if_unavailable = True
+gpgcheck = 1
+enabled=1
+
+[qubes-contrib-vm-r4.1-current-testing]
+name = Qubes OS Contrib Repository for VM (updates-testing)
+baseurl = https://contrib.qubes-os.org/yum/r4.1/current-testing/vm/opensuse/leap/$releasever
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-centos
+skip_if_unavailable = True
+gpgcheck = 1
+enabled=0

--- a/repos/qubes-contrib-vm-r4.1.repo-opensuse
+++ b/repos/qubes-contrib-vm-r4.1.repo-opensuse
@@ -1,7 +1,7 @@
 [qubes-contrib-vm-r4.1-current]
 name = Qubes OS Contrib Repository for VM (updates)
 baseurl = https://contrib.qubes-os.org/yum/r4.1/current/vm/opensuse/leap/$releasever
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-centos
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-opensuse
 skip_if_unavailable = True
 gpgcheck = 1
 enabled=1
@@ -9,7 +9,7 @@ enabled=1
 [qubes-contrib-vm-r4.1-current-testing]
 name = Qubes OS Contrib Repository for VM (updates-testing)
 baseurl = https://contrib.qubes-os.org/yum/r4.1/current-testing/vm/opensuse/leap/$releasever
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-centos
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-qubes-4-contrib-opensuse
 skip_if_unavailable = True
 gpgcheck = 1
 enabled=0

--- a/rpm_spec/qubes-vm-meta-packages.spec.in
+++ b/rpm_spec/qubes-vm-meta-packages.spec.in
@@ -25,7 +25,11 @@ Summary:    Meta package with packages required in Qubes VM
 Requires:   qubes-core-agent
 Requires:   qubes-core-agent-systemd
 Requires:   qubes-gui-agent
+%if 0%{?suse_version} == 1500 && 0%{?is_opensuse}
+Requires:   xen
+%else
 Requires:   xen-runtime
+%endif
 
 %description -n qubes-vm-dependencies
 This package depends on packages required to be installed in Qubes VM.
@@ -69,6 +73,16 @@ Requires:   xorg-x11
 Requires:   xorg-x11-server
 Requires:   xorg-x11-server-extra
 Requires:   xorg-x11-essentials
+# In openSUSE Xorg utils are in separate packages
+# TODO Figure out what utils qubes really uses and include only those
+Requires:   xdpyinfo
+Requires:   xev
+Requires:   xlsatoms
+Requires:   xlsclients
+Requires:   xlsfonts
+Requires:   xprop
+Requires:   xvinfo
+Requires:   xwininfo
 %else
 Requires:   xorg-x11-server-Xorg
 Requires:   xorg-x11-server-Xephyr


### PR DESCRIPTION
In openSUSE there's no xen-runtime package so require xen instead. Also
xorg-x11-utils package is split in different packages.